### PR TITLE
Add combined test runner

### DIFF
--- a/pymk.py
+++ b/pymk.py
@@ -14,6 +14,11 @@ def default ():
 def tests ():
     ex ('gcc -Wall -g -o bin/tests tests.c -lm -lrt')
 
+def run_tests ():
+    tests()
+    ex('./bin/tests')
+    ex('python3 python/execute_tests.py')
+
 def linear_solver_usage ():
     ex ('gcc -Wall -g -o bin/linear_solver linear_solver_usage.c -lm -lrt')
 


### PR DESCRIPTION
## Summary
- add a `run_tests` command to `pymk.py` to compile C tests and run both C and Python tests

## Testing
- `./pymk.py run_tests`

------
https://chatgpt.com/codex/tasks/task_e_68803a72f954832ba493849bd5dda2ed