### PR TITLE
Improve geometry test output grouping

### DIFF
--- a/pymk.py
+++ b/pymk.py
@@ -16,7 +16,9 @@ def tests ():
 
 def run_tests ():
     tests()
+    print(ecma_bold('== C Tests =='))
     ex('./bin/tests')
+    print(ecma_bold('== Python Tests =='))
     ex('python3 python/execute_tests.py')
 
 def linear_solver_usage ():

--- a/python/execute_tests.py
+++ b/python/execute_tests.py
@@ -1,6 +1,8 @@
 from geometry import *
 
 def geometry_tests ():
+    test_push('Geometry')
+
     p1 = Point(0, 0)
     p2 = Point(8, 0)
 
@@ -15,10 +17,6 @@ def geometry_tests ():
 
     d1 = Segment(p1, p4)
     d2 = Segment(p2, p3)
-
-
-    print (f's1 = {s1}')
-    print (f's2 = {s2}')
 
     points_collinear_test (p1, p1, p1, True)
     points_collinear_test (p1, p1, Point(5,0), True)
@@ -64,6 +62,8 @@ def geometry_tests ():
     points_sort_test ([p1, p2, p3, p4], o, [p2, p1, p3, p4], reverse=True)
     points_sort_test ([p1, Point(8, 4), p2, p4], o, [Point(8, 4), p4, p1, p2])
     points_sort_test ([p1, Point(8, 4), p2, p4], o, [p2, p1, p4, Point(8, 4)], reverse=True)
+
+    test_pop()
 
 if __name__ == "__main__":
     geometry_tests()


### PR DESCRIPTION
## Summary
- group geometry tests under a single `Geometry` category
- show clear titles when running C and Python tests

## Testing
- `python3 pymk.py run_tests`

------
https://chatgpt.com/codex/tasks/task_e_688041423a9c832baa81e04e1f9ae1dd