### PR TITLE
Add memory pool unit tests

### DIFF
--- a/memory_pool_tests.c
+++ b/memory_pool_tests.c
@@ -1,83 +1,144 @@
 /*
- * Copyright (C) 2019 Santiago León O.
+ * Memory pool unit tests replacing debug output.
  */
 
-struct test_structure_t {
-    int i;
-    float f;
-    string_t *str;
-    string_t str_set;
+struct mp_test_struct_t {
+    int value;
 };
 
-ON_DESTROY_CALLBACK(print_total)
+ON_DESTROY_CALLBACK(inc_counter)
 {
-    struct test_structure_t *test = (struct test_structure_t*)allocated;
-    printf ("Destroyed struct:\n");
-    printf (" i: %d\n", test->i);
-    printf (" f: %f\n", test->f);
-
-    // These are illegal because they have already been freed!!
-    // This shows why I don't like callbacks in general!
-    //printf (" str: %s\n", str_data(test->str));
-    //printf (" str_set: %s\n", str_data(&test->str_set));
-    printf ("\n");
+    int *counter = clsr;
+    (*counter)++;
 }
 
-void push_test_struct (mem_pool_t *pool, int i, float f, char *str)
+void memory_pool_tests(struct test_ctx_t *t)
 {
-    struct test_structure_t *test_struct = 
-        (struct test_structure_t*) mem_pool_push_size_cb(pool, sizeof(struct test_structure_t), print_total);
-    test_struct->str_set = str_new ("");
-    test_struct->i = i;
-    test_struct->f = f;
+    test_push(t, "Memory Pool");
 
-    // Test pooled strings
-    test_struct->str = str_new_pooled (pool, str);
-    str_set_pooled (pool, &test_struct->str_set, str);
-    str_cat_c (&test_struct->str_set, "(set)");
+    /* Destroy callback */
+    {
+        test_push(t, "destroy callback");
+        mem_pool_t pool = {0};
+        int counter = 0;
+
+        mem_pool_push_size_full(&pool, sizeof(struct mp_test_struct_t),
+                               POOL_UNINITIALIZED,
+                               inc_counter, &counter);
+        mem_pool_destroy(&pool);
+        bool success = counter == 1;
+        if (!success) {
+            test_error_current(t, "expected 1 callback, got %d\n", counter);
+        }
+        test_pop(t, success);
+    }
+
+    /* Temporary memory marker */
+    {
+        test_push(t, "temporary memory");
+        mem_pool_t pool = {0};
+        int counter = 0;
+
+        mem_pool_push_size_full(&pool, sizeof(struct mp_test_struct_t),
+                               POOL_UNINITIALIZED,
+                               inc_counter, &counter);
+        void *base_before = pool.base;
+        uint32_t used_before = pool.used;
+        uint32_t total_before = pool.total_data;
+
+        mem_pool_marker_t marker = mem_pool_begin_temporary_memory(&pool);
+        mem_pool_push_size_full(&pool, sizeof(struct mp_test_struct_t),
+                               POOL_UNINITIALIZED,
+                               inc_counter, &counter);
+        mem_pool_end_temporary_memory(marker);
+
+        bool success = counter == 1 && pool.base == base_before &&
+                       pool.used == used_before &&
+                       pool.total_data == total_before;
+        if (!success) {
+            test_error_current(t, "marker restoration failed\n");
+        }
+        mem_pool_destroy(&pool);
+        if (counter != 2) {
+            success = false;
+            test_error_current(t, "expected 2 callbacks after destroy, got %d\n", counter);
+        }
+        test_pop(t, success);
+    }
+
+    /* Marker before pool initialization */
+    {
+        test_push(t, "marker before init");
+        mem_pool_t pool = {0};
+        int counter = 0;
+
+        mem_pool_marker_t marker = mem_pool_begin_temporary_memory(&pool);
+        mem_pool_push_size_full(&pool, sizeof(struct mp_test_struct_t),
+                               POOL_UNINITIALIZED,
+                               inc_counter, &counter);
+        mem_pool_end_temporary_memory(marker);
+
+        bool success = counter == 1 && pool.base == NULL && pool.size == 0 &&
+                       pool.used == 0 && pool.total_data == 0;
+        if (!success) {
+            test_error_current(t, "pool not reset after marker\n");
+        }
+        mem_pool_destroy(&pool);
+        if (counter != 1) {
+            success = false;
+            test_error_current(t, "unexpected callbacks after destroy: %d\n", counter);
+        }
+        test_pop(t, success);
+    }
+
+    /* Nested markers */
+    {
+        test_push(t, "nested markers");
+        mem_pool_t pool = {0};
+        int counter = 0;
+
+        mem_pool_push_size_full(&pool, sizeof(struct mp_test_struct_t),
+                               POOL_UNINITIALIZED,
+                               inc_counter, &counter);
+        mem_pool_marker_t m1 = mem_pool_begin_temporary_memory(&pool);
+        mem_pool_push_size_full(&pool, sizeof(struct mp_test_struct_t),
+                               POOL_UNINITIALIZED,
+                               inc_counter, &counter);
+        mem_pool_marker_t m2 = mem_pool_begin_temporary_memory(&pool);
+        mem_pool_push_size_full(&pool, sizeof(struct mp_test_struct_t),
+                               POOL_UNINITIALIZED,
+                               inc_counter, &counter);
+        mem_pool_end_temporary_memory(m2);
+        bool success = counter == 1;
+        mem_pool_end_temporary_memory(m1);
+        success = success && counter == 2;
+        mem_pool_destroy(&pool);
+        success = success && counter == 3;
+        if (!success) {
+            test_error_current(t, "nested marker callbacks mismatch: %d\n", counter);
+        }
+        test_pop(t, success);
+    }
+
+    /* Child pool cleanup */
+    {
+        test_push(t, "child pool");
+        mem_pool_t parent = {0};
+        mem_pool_t child = {0};
+        int counter = 0;
+
+        mem_pool_add_child(&parent, &child);
+        mem_pool_push_size_full(&child, sizeof(struct mp_test_struct_t),
+                               POOL_UNINITIALIZED,
+                               inc_counter, &counter);
+        mem_pool_destroy(&parent);
+        bool success = counter == 1;
+        if (!success) {
+            test_error_current(t, "child callback count %d\n", counter);
+        }
+        test_pop(t, success);
+    }
+
+    test_pop_parent(t);
 }
 
-void memory_pool_tests ()
-{
-    mem_pool_t pool = {0};
-
-    size_t expected_struct_size =
-        sizeof(struct test_structure_t) +
-        sizeof(struct on_destroy_callback_info_t)*3 + /*print_total() callback + 2 pooled strings*/
-        sizeof(string_t);
-
-    // We make a bin big enough to hold exactly 2 structs allocated by push_test_struct.
-    pool.min_bin_size = expected_struct_size*2;
-
-    printf ("sizeof(struct bin_info_t) = %ld\n", sizeof(bin_info_t));
-    printf ("sizeof(struct test_structure_t) = %ld\n", sizeof(struct test_structure_t));
-    printf ("sizeof(struct on_destroy_callback_info_t) = %ld\n", sizeof(struct on_destroy_callback_info_t));
-    printf ("sizeof(string_t) = %ld\n", sizeof(string_t));
-    printf ("Expected struct size = %ld\n", expected_struct_size);
-    printf ("\n");
-
-    printf ("Allocate 1st struct.\n");
-    push_test_struct (&pool, 10, 5.5, "This is a long string that will force a malloc");
-    mem_pool_print (&pool);
-    printf ("\n");
-
-    printf ("----TEMPORARY MEMORY START----\n");
-    mem_pool_marker_t mrkr = mem_pool_begin_temporary_memory (&pool);
-
-    printf ("Allocate 2nd struct.\n");
-    push_test_struct (&pool, 4, 1.5, "And another long string");
-    mem_pool_print (&pool);
-    printf ("\n");
-
-    printf ("Allocate 3rd struct.\n");
-    push_test_struct (&pool, 20, 3.25, "bar");
-    mem_pool_print (&pool);
-    printf ("\n");
-
-    mem_pool_end_temporary_memory (mrkr);
-    printf ("----TEMPORARY MEMORY END----\n");
-
-    mem_pool_print (&pool);
-
-    mem_pool_destroy (&pool);
-}

--- a/tests.c
+++ b/tests.c
@@ -52,7 +52,7 @@ int main (int argc, char **argv)
     //t.show_all_children = true;
 
     // TODO: Add these to test logger
-    memory_pool_tests ();
+    memory_pool_tests (&t);
 
     test_logger_tests (&t);
 


### PR DESCRIPTION
## Summary
- replace debug-based memory pool tests with proper unit tests
- call new tests from the main test runner

## Testing
- `python3 pymk.py run_tests`

------
https://chatgpt.com/codex/tasks/task_e_688056a0918c832b9544bd56ce6cbe1c